### PR TITLE
update to Macro api and allowing users to provide a custom Macro code

### DIFF
--- a/api/pom.xml
+++ b/api/pom.xml
@@ -212,7 +212,7 @@
         <plugin>
           <groupId>org.jacoco</groupId>
           <artifactId>jacoco-maven-plugin</artifactId>
-          <version>0.8.4</version>
+          <version>0.8.8</version>
         </plugin>
         <plugin>
           <groupId>org.hibernate.orm.tooling</groupId>

--- a/api/src/main/java/ca/bc/gov/educ/api/macro/repository/MacroRepository.java
+++ b/api/src/main/java/ca/bc/gov/educ/api/macro/repository/MacroRepository.java
@@ -13,6 +13,8 @@ public interface MacroRepository extends JpaRepository<MacroEntity, UUID> {
 
   List<MacroEntity> findAllByBusinessUseTypeCodeAndMacroTypeCode(String businessUseTypeCode, String macroTypeCode);
 
+  List<MacroEntity> findAllByBusinessUseTypeCodeAndMacroTypeCodeAndMacroCode(String businessUseTypeCode, String macroTypeCode, String macroCode);
+
   List<MacroEntity> findAllByBusinessUseTypeCode(String businessUseTypeCode);
 
   List<MacroEntity> findAllByBusinessUseTypeCodeIn(Collection<String> businessUseTypeCodes);

--- a/api/src/main/java/ca/bc/gov/educ/api/macro/validator/MacroPayloadValidator.java
+++ b/api/src/main/java/ca/bc/gov/educ/api/macro/validator/MacroPayloadValidator.java
@@ -1,6 +1,8 @@
 package ca.bc.gov.educ.api.macro.validator;
 
+import ca.bc.gov.educ.api.macro.repository.*;
 import ca.bc.gov.educ.api.macro.struct.v1.Macro;
+import org.springframework.beans.factory.annotation.*;
 import org.springframework.stereotype.Component;
 import org.springframework.validation.FieldError;
 
@@ -9,12 +11,26 @@ import java.util.List;
 
 @Component
 public class MacroPayloadValidator {
+
+  private MacroRepository macroRepository;
+
   public static final String BUSINESS_USE_TYPE_CODE = "businessUseTypeCode";
+
+  @Autowired
+  public MacroPayloadValidator(MacroRepository macroRepository) {
+    this.macroRepository = macroRepository;
+  }
 
   public List<FieldError> validatePayload(Macro macro, boolean isCreateOperation, List<String> BusinessUseTypeCodes) {
     final List<FieldError> apiValidationErrors = new ArrayList<>();
     if (isCreateOperation && macro.getMacroId() != null) {
       apiValidationErrors.add(createFieldError("macroId", macro.getMacroId(), "macroId should be null for post operation."));
+    }
+    if (isCreateOperation) {
+      var macroList = macroRepository.findAllByBusinessUseTypeCodeAndMacroTypeCodeAndMacroCode(macro.getBusinessUseTypeCode(), macro.getMacroTypeCode(), macro.getMacroCode());
+      if (!macroList.isEmpty()) {
+        apiValidationErrors.add(createFieldError("uniqueConstraintBusinessUseTypeCodeAndMacroTypeCodeAndMacroCode", macro, "combination of BusinessUseTypeCode, MacroTypeCode and MacroCode already exists"));
+      }
     }
     if(!BusinessUseTypeCodes.contains(macro.getBusinessUseTypeCode())) {
       apiValidationErrors.add(createFieldError(BUSINESS_USE_TYPE_CODE, macro.getBusinessUseTypeCode(), "businessUseTypeCode Invalid."));

--- a/api/src/test/java/ca/bc/gov/educ/api/macro/controller/v1/PenMacroControllerTest.java
+++ b/api/src/test/java/ca/bc/gov/educ/api/macro/controller/v1/PenMacroControllerTest.java
@@ -187,6 +187,19 @@ public class PenMacroControllerTest {
       .andDo(print()).andExpect(status().isOk()).andExpect(jsonPath("$").exists());
   }
 
+  @Test
+  public void testCreateMacro_GivenDuplicateMacroPayload_ShouldReturnStatusBadRequest() throws Exception {
+    MacroEntity macroEntity = createMacroEntities("PENREG");
+    this.macroRepository.save(macroEntity);
+
+    this.mockMvc.perform(MockMvcRequestBuilders.post(URL.BASE_URL + URL.PEN_MACRO + "/create-macro")
+            .with(jwt().jwt((jwt) -> jwt.claim("scope", "WRITE_PEN_MACRO")))
+            .contentType(MediaType.APPLICATION_JSON)
+            .accept(MediaType.APPLICATION_JSON)
+            .content(dummyMacroJson("PENREG")))
+        .andDo(print()).andExpect(status().isBadRequest());
+  }
+
   //update macro saga
   @Test
   public void testUpdateMacro_GivenInvalidPayload_ShouldReturnStatusBadRequest() throws Exception {

--- a/api/src/test/java/ca/bc/gov/educ/api/macro/validator/MacroPayloadValidatorTest.java
+++ b/api/src/test/java/ca/bc/gov/educ/api/macro/validator/MacroPayloadValidatorTest.java
@@ -2,6 +2,7 @@ package ca.bc.gov.educ.api.macro.validator;
 
 import ca.bc.gov.educ.api.macro.MacroApiResourceApplication;
 import ca.bc.gov.educ.api.macro.constants.BusinessUseTypeCodes;
+import ca.bc.gov.educ.api.macro.repository.*;
 import ca.bc.gov.educ.api.macro.struct.v1.Macro;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.val;
@@ -11,6 +12,7 @@ import org.junit.runner.RunWith;
 import org.mockito.InjectMocks;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.*;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.junit4.SpringRunner;
 
@@ -26,11 +28,14 @@ public class MacroPayloadValidatorTest {
   @InjectMocks
   MacroPayloadValidator macroPayloadValidator;
 
+  @MockBean
+  private MacroRepository macroRepository;
+
   List<String> businessUseTypeCodes = List.of(BusinessUseTypeCodes.GMP.toString(), BusinessUseTypeCodes.UMP.toString(), BusinessUseTypeCodes.PENREG.toString());
 
   @Before
   public void before() {
-    this.macroPayloadValidator = new MacroPayloadValidator();
+    this.macroPayloadValidator = new MacroPayloadValidator(macroRepository);
   }
 
   @Test


### PR DESCRIPTION
Reason for change 
- creating a Macro is a saga. 
- we need to confirm that the Macro the user wants to create doesn't already exist (otherwise the saga would fail forever due to the primary unique key constraint). 