### PR TITLE
Feature/hd 10705

### DIFF
--- a/api/pom.xml
+++ b/api/pom.xml
@@ -212,7 +212,7 @@
         <plugin>
           <groupId>org.jacoco</groupId>
           <artifactId>jacoco-maven-plugin</artifactId>
-          <version>0.8.4</version>
+          <version>0.8.8</version>
         </plugin>
         <plugin>
           <groupId>org.hibernate.orm.tooling</groupId>
@@ -334,7 +334,6 @@
           <plugin>
             <groupId>org.jacoco</groupId>
             <artifactId>jacoco-maven-plugin</artifactId>
-            <version>0.8.4</version>
             <executions>
               <execution>
                 <id>prepare-agent</id>

--- a/api/src/main/java/ca/bc/gov/educ/api/macro/repository/MacroRepository.java
+++ b/api/src/main/java/ca/bc/gov/educ/api/macro/repository/MacroRepository.java
@@ -13,6 +13,8 @@ public interface MacroRepository extends JpaRepository<MacroEntity, UUID> {
 
   List<MacroEntity> findAllByBusinessUseTypeCodeAndMacroTypeCode(String businessUseTypeCode, String macroTypeCode);
 
+  List<MacroEntity> findAllByBusinessUseTypeCodeAndMacroTypeCodeAndMacroCode(String businessUseTypeCode, String macroTypeCode, String macroCode);
+
   List<MacroEntity> findAllByBusinessUseTypeCode(String businessUseTypeCode);
 
   List<MacroEntity> findAllByBusinessUseTypeCodeIn(Collection<String> businessUseTypeCodes);

--- a/api/src/main/java/ca/bc/gov/educ/api/macro/validator/MacroPayloadValidator.java
+++ b/api/src/main/java/ca/bc/gov/educ/api/macro/validator/MacroPayloadValidator.java
@@ -1,6 +1,8 @@
 package ca.bc.gov.educ.api.macro.validator;
 
+import ca.bc.gov.educ.api.macro.repository.*;
 import ca.bc.gov.educ.api.macro.struct.v1.Macro;
+import org.springframework.beans.factory.annotation.*;
 import org.springframework.stereotype.Component;
 import org.springframework.validation.FieldError;
 
@@ -9,12 +11,26 @@ import java.util.List;
 
 @Component
 public class MacroPayloadValidator {
+
+  private MacroRepository macroRepository;
+
   public static final String BUSINESS_USE_TYPE_CODE = "businessUseTypeCode";
+
+  @Autowired
+  public MacroPayloadValidator(MacroRepository macroRepository) {
+    this.macroRepository = macroRepository;
+  }
 
   public List<FieldError> validatePayload(Macro macro, boolean isCreateOperation, List<String> BusinessUseTypeCodes) {
     final List<FieldError> apiValidationErrors = new ArrayList<>();
     if (isCreateOperation && macro.getMacroId() != null) {
       apiValidationErrors.add(createFieldError("macroId", macro.getMacroId(), "macroId should be null for post operation."));
+    }
+    if (isCreateOperation) {
+      var macroList = macroRepository.findAllByBusinessUseTypeCodeAndMacroTypeCodeAndMacroCode(macro.getBusinessUseTypeCode(), macro.getMacroTypeCode(), macro.getMacroCode());
+      if (!macroList.isEmpty()) {
+        apiValidationErrors.add(createFieldError("uniqueConstraintBusinessUseTypeCodeAndMacroTypeCodeAndMacroCode", macro, "combination of BusinessUseTypeCode, MacroTypeCode and MacroCode already exists"));
+      }
     }
     if(!BusinessUseTypeCodes.contains(macro.getBusinessUseTypeCode())) {
       apiValidationErrors.add(createFieldError(BUSINESS_USE_TYPE_CODE, macro.getBusinessUseTypeCode(), "businessUseTypeCode Invalid."));

--- a/api/src/test/java/ca/bc/gov/educ/api/macro/controller/v1/MacroAPIControllerTest.java
+++ b/api/src/test/java/ca/bc/gov/educ/api/macro/controller/v1/MacroAPIControllerTest.java
@@ -92,7 +92,7 @@ public class MacroAPIControllerTest {
   @Test
   public void testReadSaga_GivenInValidID_ShouldReturnStatusNotFound() throws Exception {
     this.mockMvc.perform(get(URL.BASE_URL + "/saga/" + UUID.randomUUID().toString())
-            .with(jwt().jwt((jwt) -> jwt.claim("scope", "MACRO_READ_SAGA")))
+            .with(jwt().jwt(jwt -> jwt.claim("scope", "MACRO_READ_SAGA")))
             .contentType(MediaType.APPLICATION_JSON)
             .accept(MediaType.APPLICATION_JSON))
             .andDo(print()).andExpect(status().isNotFound());
@@ -104,7 +104,7 @@ public class MacroAPIControllerTest {
     var sagaFromDB = sagaService.createSagaRecordInDB(SagaEnum.MACRO_CREATE_SAGA.toString(), "Test", payload, UUID.fromString(macroID));
 
     this.mockMvc.perform(get(URL.BASE_URL + "/saga/" + sagaFromDB.getSagaId().toString())
-            .with(jwt().jwt((jwt) -> jwt.claim("scope", "MACRO_READ_SAGA")))
+            .with(jwt().jwt(jwt -> jwt.claim("scope", "MACRO_READ_SAGA")))
             .contentType(MediaType.APPLICATION_JSON)
             .accept(MediaType.APPLICATION_JSON))
             .andDo(print()).andExpect(status().isOk())
@@ -129,7 +129,7 @@ public class MacroAPIControllerTest {
     this.repository.saveAll(sagaEntities);
     final MvcResult result = this.mockMvc
       .perform(get("/api/v1/macro/saga/paginated")
-        .with(jwt().jwt((jwt) -> jwt.claim("scope", "MACRO_READ_SAGA")))
+        .with(jwt().jwt(jwt -> jwt.claim("scope", "MACRO_READ_SAGA")))
         .contentType(APPLICATION_JSON))
       .andReturn();
     this.mockMvc.perform(asyncDispatch(result)).andDo(print()).andExpect(status().isOk()).andExpect(jsonPath("$.content", hasSize(3)));
@@ -140,7 +140,7 @@ public class MacroAPIControllerTest {
   public void testGetSagaPaginated_givenNoData_shouldReturnStatusOk() throws Exception {
     final MvcResult result = this.mockMvc
       .perform(get("/api/v1/macro/saga/paginated")
-        .with(jwt().jwt((jwt) -> jwt.claim("scope", "MACRO_READ_SAGA")))
+        .with(jwt().jwt(jwt -> jwt.claim("scope", "MACRO_READ_SAGA")))
         .contentType(APPLICATION_JSON))
       .andReturn();
     this.mockMvc.perform(asyncDispatch(result)).andDo(print()).andExpect(status().isOk()).andExpect(jsonPath("$.content", hasSize(0)));
@@ -175,7 +175,7 @@ public class MacroAPIControllerTest {
 
     final MvcResult result = this.mockMvc
       .perform(get("/api/v1/macro/saga/paginated")
-        .with(jwt().jwt((jwt) -> jwt.claim("scope", "MACRO_READ_SAGA")))
+        .with(jwt().jwt(jwt -> jwt.claim("scope", "MACRO_READ_SAGA")))
         .param("searchCriteriaList", criteriaJSON)
         .contentType(APPLICATION_JSON))
       .andReturn();
@@ -186,7 +186,7 @@ public class MacroAPIControllerTest {
   @SuppressWarnings("java:S100")
   public void testReadSagaEvents_givenSagaDoesntExist_shouldReturnStatusNotFound() throws Exception {
     this.mockMvc.perform(get("/api/v1/macro/saga/{sagaId}/saga-events", UUID.randomUUID())
-      .with(jwt().jwt((jwt) -> jwt.claim("scope", "MACRO_READ_SAGA")))
+      .with(jwt().jwt(jwt -> jwt.claim("scope", "MACRO_READ_SAGA")))
       .contentType(APPLICATION_JSON)).andDo(print()).andExpect(status().isNotFound());
   }
 
@@ -212,14 +212,14 @@ public class MacroAPIControllerTest {
     }
     this.sagaEventRepository.saveAll(sagaEvents);
     this.mockMvc.perform(get("/api/v1/macro/saga/{sagaId}/saga-events", saga.getSagaId())
-      .with(jwt().jwt((jwt) -> jwt.claim("scope", "MACRO_READ_SAGA"))))
+      .with(jwt().jwt(jwt -> jwt.claim("scope", "MACRO_READ_SAGA"))))
       .andDo(print()).andExpect(status().isOk()).andExpect(jsonPath("$", hasSize(3)));
   }
 
   @Test
   public void testUpdateSaga_givenNoBody_shouldReturn400() throws Exception {
     this.mockMvc.perform(put("/api/v1/macro/saga/{sagaId}", UUID.randomUUID())
-      .with(jwt().jwt((jwt) -> jwt.claim("scope", "MACRO_WRITE_SAGA")))
+      .with(jwt().jwt(jwt -> jwt.claim("scope", "MACRO_WRITE_SAGA")))
       .contentType(APPLICATION_JSON)).andDo(print()).andExpect(status().isBadRequest());
   }
 
@@ -227,7 +227,7 @@ public class MacroAPIControllerTest {
   public void testUpdateSaga_givenInvalidID_shouldReturn404() throws Exception {
     val saga = createMockSaga();
     this.mockMvc.perform(put("/api/v1/macro/saga/{sagaId}", UUID.randomUUID()).content(objectMapper.writeValueAsBytes(saga))
-      .with(jwt().jwt((jwt) -> jwt.claim("scope", "MACRO_WRITE_SAGA")))
+      .with(jwt().jwt(jwt -> jwt.claim("scope", "MACRO_WRITE_SAGA")))
       .contentType(APPLICATION_JSON)).andDo(print()).andExpect(status().isNotFound());
   }
 
@@ -236,7 +236,7 @@ public class MacroAPIControllerTest {
     final var sagaFromDB = this.sagaService.createSagaRecordInDB(MACRO_CREATE_SAGA.toString(), "Test", "Test", UUID.fromString(this.macroID));
     sagaFromDB.setUpdateDate(LocalDateTime.now());
     this.mockMvc.perform(put("/api/v1/macro/saga/{sagaId}", sagaFromDB.getSagaId()).content(objectMapper.writeValueAsBytes(mapper.toStruct(sagaFromDB)))
-      .with(jwt().jwt((jwt) -> jwt.claim("scope", "MACRO_WRITE_SAGA")))
+      .with(jwt().jwt(jwt -> jwt.claim("scope", "MACRO_WRITE_SAGA")))
       .contentType(APPLICATION_JSON)).andDo(print()).andExpect(status().isConflict());
   }
 
@@ -245,7 +245,7 @@ public class MacroAPIControllerTest {
     final var sagaFromDB = this.sagaService.createSagaRecordInDB(MACRO_CREATE_SAGA.toString(), "Test", "Test", UUID.fromString(this.macroID));
     sagaFromDB.setUpdateDate(sagaFromDB.getUpdateDate().withNano((int)Math.round(sagaFromDB.getUpdateDate().getNano()/1000.00)*1000)); //db limits precision, so need to adjust
     this.mockMvc.perform(put("/api/v1/macro/saga/{sagaId}", sagaFromDB.getSagaId()).content(objectMapper.writeValueAsBytes(mapper.toStruct(sagaFromDB)))
-      .with(jwt().jwt((jwt) -> jwt.claim("scope", "MACRO_WRITE_SAGA")))
+      .with(jwt().jwt(jwt -> jwt.claim("scope", "MACRO_WRITE_SAGA")))
       .contentType(APPLICATION_JSON)).andDo(print()).andExpect(status().isOk());
   }
 

--- a/api/src/test/java/ca/bc/gov/educ/api/macro/controller/v1/PenMacroControllerTest.java
+++ b/api/src/test/java/ca/bc/gov/educ/api/macro/controller/v1/PenMacroControllerTest.java
@@ -82,14 +82,14 @@ public class PenMacroControllerTest {
   @Test
   public void testRetrievePenMacros_ShouldReturnStatusOK() throws Exception {
     this.mockMvc.perform(MockMvcRequestBuilders.get(URL.BASE_URL + URL.PEN_MACRO)
-            .with(jwt().jwt((jwt) -> jwt.claim("scope", "READ_PEN_MACRO"))))
+            .with(jwt().jwt(jwt -> jwt.claim("scope", "READ_PEN_MACRO"))))
             .andDo(print()).andExpect(status().isOk());
   }
 
   @Test
   public void testRetrievePenMacros_GivenInvalidMacroID_ShouldReturnStatusNotFound() throws Exception {
     this.mockMvc.perform(MockMvcRequestBuilders.get(URL.BASE_URL + URL.PEN_MACRO + URL.MACRO_ID,UUID.randomUUID().toString())
-            .with(jwt().jwt((jwt) -> jwt.claim("scope", "READ_PEN_MACRO"))))
+            .with(jwt().jwt(jwt -> jwt.claim("scope", "READ_PEN_MACRO"))))
             .andDo(print()).andExpect(status().isNotFound());
   }
 
@@ -97,7 +97,7 @@ public class PenMacroControllerTest {
   public void testRetrievePenMacros_GivenMacroIDWithInvalidBusinessUseTypeCode_ShouldReturnStatusNotFound() throws Exception {
     MacroEntity savedEntity = createMacroEntities("OTHER");
     this.mockMvc.perform(MockMvcRequestBuilders.get(URL.BASE_URL + URL.PEN_MACRO + URL.MACRO_ID,savedEntity.getMacroId().toString())
-      .with(jwt().jwt((jwt) -> jwt.claim("scope", "READ_PEN_MACRO"))))
+      .with(jwt().jwt(jwt -> jwt.claim("scope", "READ_PEN_MACRO"))))
       .andDo(print()).andExpect(status().isNotFound());
   }
 
@@ -105,7 +105,7 @@ public class PenMacroControllerTest {
   public void testRetrievePenMacros_GivenValidMacroID_ShouldReturnStatusOK() throws Exception {
     MacroEntity savedEntity = createMacroEntities("GMP");
     final var result = this.mockMvc.perform(MockMvcRequestBuilders.get(URL.BASE_URL + URL.PEN_MACRO + URL.MACRO_ID, savedEntity.getMacroId().toString())
-            .with(jwt().jwt((jwt) -> jwt.claim("scope", "READ_PEN_MACRO"))))
+            .with(jwt().jwt(jwt -> jwt.claim("scope", "READ_PEN_MACRO"))))
             .andDo(print()).andExpect(jsonPath("$.macroId").value(savedEntity.getMacroId().toString())).andExpect(status().isOk()).andReturn();
     assertThat(result).isNotNull();
   }
@@ -114,7 +114,7 @@ public class PenMacroControllerTest {
   public void testRetrievePenMacros_GivenValidBusinessUseTypeCode_ShouldReturnStatusOK() throws Exception {
     MacroEntity savedEntity = createMacroEntities("GMP");
     final var result = this.mockMvc.perform(MockMvcRequestBuilders.get(URL.BASE_URL + URL.PEN_MACRO +"?businessUseTypeCode=" + savedEntity.getBusinessUseTypeCode())
-      .with(jwt().jwt((jwt) -> jwt.claim("scope", "READ_PEN_MACRO"))))
+      .with(jwt().jwt(jwt -> jwt.claim("scope", "READ_PEN_MACRO"))))
       .andDo(print()).andExpect(status().isOk()).andExpect(jsonPath("$", hasSize(1)));
     assertThat(result).isNotNull();
   }
@@ -123,7 +123,7 @@ public class PenMacroControllerTest {
   public void testRetrievePenMacros_GivenInvalidBusinessUseTypeCode_ShouldReturnStatusOK() throws Exception {
     MacroEntity savedEntity = createMacroEntities("OTHER");
     final var result = this.mockMvc.perform(MockMvcRequestBuilders.get(URL.BASE_URL + URL.PEN_MACRO +"?businessUseTypeCode=" + savedEntity.getBusinessUseTypeCode())
-      .with(jwt().jwt((jwt) -> jwt.claim("scope", "READ_PEN_MACRO"))))
+      .with(jwt().jwt(jwt -> jwt.claim("scope", "READ_PEN_MACRO"))))
       .andDo(print()).andExpect(status().isOk()).andExpect(jsonPath("$", hasSize(0)));
     assertThat(result).isNotNull();
   }
@@ -132,7 +132,7 @@ public class PenMacroControllerTest {
   public void testRetrievePenMacros_GivenValidBusinessUseTypeCodeAndMacroTypeCode_ShouldReturnStatusOK() throws Exception {
     MacroEntity savedEntity = createMacroEntities("GMP");
     final var result = this.mockMvc.perform(MockMvcRequestBuilders.get(URL.BASE_URL + URL.PEN_MACRO +"?businessUseTypeCode=" + savedEntity.getBusinessUseTypeCode() + "&macroTypeCode=" + savedEntity.getMacroTypeCode())
-            .with(jwt().jwt((jwt) -> jwt.claim("scope", "READ_PEN_MACRO"))))
+            .with(jwt().jwt(jwt -> jwt.claim("scope", "READ_PEN_MACRO"))))
             .andDo(print()).andExpect(status().isOk()).andExpect(jsonPath("$", hasSize(1)));
     assertThat(result).isNotNull();
   }
@@ -141,7 +141,7 @@ public class PenMacroControllerTest {
   public void testRetrievePenMacros_GivenInvalidBusinessUseTypeCodeAndMacroTypeCode_ShouldReturnStatusOK() throws Exception {
     MacroEntity savedEntity = createMacroEntities("OTHER");
     final var result = this.mockMvc.perform(MockMvcRequestBuilders.get(URL.BASE_URL + URL.PEN_MACRO +"?businessUseTypeCode=" + savedEntity.getBusinessUseTypeCode() + "&macroTypeCode=" + savedEntity.getMacroTypeCode())
-      .with(jwt().jwt((jwt) -> jwt.claim("scope", "READ_PEN_MACRO"))))
+      .with(jwt().jwt(jwt -> jwt.claim("scope", "READ_PEN_MACRO"))))
       .andDo(print()).andExpect(status().isOk()).andExpect(jsonPath("$", hasSize(0)));
     assertThat(result).isNotNull();
   }
@@ -150,7 +150,7 @@ public class PenMacroControllerTest {
   @Test
   public void testCreateMacro_GivenInvalidPayload_ShouldReturnStatusBadRequest() throws Exception {
     this.mockMvc.perform(MockMvcRequestBuilders.post(URL.BASE_URL + URL.PEN_MACRO + "/create-macro")
-      .with(jwt().jwt((jwt) -> jwt.claim("scope", "WRITE_PEN_MACRO")))
+      .with(jwt().jwt(jwt -> jwt.claim("scope", "WRITE_PEN_MACRO")))
       .contentType(MediaType.APPLICATION_JSON)
       .accept(MediaType.APPLICATION_JSON)
       .content(placeholderInvalidSagaData()))
@@ -160,7 +160,7 @@ public class PenMacroControllerTest {
   @Test
   public void testCreateMacro_GivenPayloadWithMacroId_ShouldReturnStatusBadRequest() throws Exception {
     this.mockMvc.perform(MockMvcRequestBuilders.post(URL.BASE_URL + URL.PEN_MACRO + "/create-macro")
-      .with(jwt().jwt((jwt) -> jwt.claim("scope", "WRITE_PEN_MACRO")))
+      .with(jwt().jwt(jwt -> jwt.claim("scope", "WRITE_PEN_MACRO")))
       .contentType(MediaType.APPLICATION_JSON)
       .accept(MediaType.APPLICATION_JSON)
       .content(dummyMacroJsonWithId("PENREG")))
@@ -170,7 +170,7 @@ public class PenMacroControllerTest {
   @Test
   public void testCreateMacro_GivenPayloadWithInvalidBusinessUseTypeCode_ShouldReturnStatusBadRequest() throws Exception {
     this.mockMvc.perform(MockMvcRequestBuilders.post(URL.BASE_URL + URL.PEN_MACRO + "/create-macro")
-      .with(jwt().jwt((jwt) -> jwt.claim("scope", "WRITE_PEN_MACRO")))
+      .with(jwt().jwt(jwt -> jwt.claim("scope", "WRITE_PEN_MACRO")))
       .contentType(MediaType.APPLICATION_JSON)
       .accept(MediaType.APPLICATION_JSON)
       .content(dummyMacroJson("OTHER")))
@@ -180,7 +180,7 @@ public class PenMacroControllerTest {
   @Test
   public void testCreateMacro_GivenValidPayload_ShouldReturnStatusOk() throws Exception {
     this.mockMvc.perform(MockMvcRequestBuilders.post(URL.BASE_URL + URL.PEN_MACRO + "/create-macro")
-      .with(jwt().jwt((jwt) -> jwt.claim("scope", "WRITE_PEN_MACRO")))
+      .with(jwt().jwt(jwt -> jwt.claim("scope", "WRITE_PEN_MACRO")))
       .contentType(MediaType.APPLICATION_JSON)
       .accept(MediaType.APPLICATION_JSON)
       .content(dummyMacroJson("PENREG")))
@@ -193,7 +193,7 @@ public class PenMacroControllerTest {
     this.macroRepository.save(macroEntity);
 
     this.mockMvc.perform(MockMvcRequestBuilders.post(URL.BASE_URL + URL.PEN_MACRO + "/create-macro")
-            .with(jwt().jwt((jwt) -> jwt.claim("scope", "WRITE_PEN_MACRO")))
+            .with(jwt().jwt(jwt -> jwt.claim("scope", "WRITE_PEN_MACRO")))
             .contentType(MediaType.APPLICATION_JSON)
             .accept(MediaType.APPLICATION_JSON)
             .content(dummyMacroJson("PENREG")))
@@ -204,7 +204,7 @@ public class PenMacroControllerTest {
   @Test
   public void testUpdateMacro_GivenInvalidPayload_ShouldReturnStatusBadRequest() throws Exception {
     this.mockMvc.perform(MockMvcRequestBuilders.post(URL.BASE_URL + URL.PEN_MACRO + "/update-macro")
-      .with(jwt().jwt((jwt) -> jwt.claim("scope", "WRITE_PEN_MACRO")))
+      .with(jwt().jwt(jwt -> jwt.claim("scope", "WRITE_PEN_MACRO")))
       .contentType(MediaType.APPLICATION_JSON)
       .accept(MediaType.APPLICATION_JSON)
       .content(placeholderInvalidSagaData()))
@@ -214,7 +214,7 @@ public class PenMacroControllerTest {
   @Test
   public void testUpdateMacro_GivenValidPayload_ShouldReturnStatusOk() throws Exception {
     this.mockMvc.perform(MockMvcRequestBuilders.post(URL.BASE_URL + URL.PEN_MACRO + "/update-macro")
-      .with(jwt().jwt((jwt) -> jwt.claim("scope", "WRITE_PEN_MACRO")))
+      .with(jwt().jwt(jwt -> jwt.claim("scope", "WRITE_PEN_MACRO")))
       .contentType(MediaType.APPLICATION_JSON)
       .accept(MediaType.APPLICATION_JSON)
       .content(dummyMacroJsonWithId("PENREG")))
@@ -226,7 +226,7 @@ public class PenMacroControllerTest {
     var payload = dummyMacroJsonWithId("PENREG");
     sagaService.createSagaRecordInDB(SagaEnum.MACRO_UPDATE_SAGA.toString(), "Test", payload, UUID.fromString(this.macroID));
     this.mockMvc.perform(MockMvcRequestBuilders.post(URL.BASE_URL + URL.PEN_MACRO + "/update-macro")
-      .with(jwt().jwt((jwt) -> jwt.claim("scope", "WRITE_PEN_MACRO")))
+      .with(jwt().jwt(jwt -> jwt.claim("scope", "WRITE_PEN_MACRO")))
       .contentType(MediaType.APPLICATION_JSON)
       .accept(MediaType.APPLICATION_JSON)
       .content(payload))

--- a/api/src/test/java/ca/bc/gov/educ/api/macro/controller/v1/PenMacroControllerTest.java
+++ b/api/src/test/java/ca/bc/gov/educ/api/macro/controller/v1/PenMacroControllerTest.java
@@ -187,6 +187,19 @@ public class PenMacroControllerTest {
       .andDo(print()).andExpect(status().isOk()).andExpect(jsonPath("$").exists());
   }
 
+  @Test
+  public void testCreateMacro_GivenDuplicateMacroPayload_ShouldReturnStatusBadRequest() throws Exception {
+    MacroEntity macroEntity = createMacroEntities("PENREG");
+    this.macroRepository.save(macroEntity);
+
+    this.mockMvc.perform(MockMvcRequestBuilders.post(URL.BASE_URL + URL.PEN_MACRO + "/create-macro")
+            .with(jwt().jwt((jwt) -> jwt.claim("scope", "WRITE_PEN_MACRO")))
+            .contentType(MediaType.APPLICATION_JSON)
+            .accept(MediaType.APPLICATION_JSON)
+            .content(dummyMacroJson("PENREG")))
+        .andDo(print()).andExpect(status().isBadRequest());
+  }
+
   //update macro saga
   @Test
   public void testUpdateMacro_GivenInvalidPayload_ShouldReturnStatusBadRequest() throws Exception {

--- a/api/src/test/java/ca/bc/gov/educ/api/macro/validator/MacroPayloadValidatorTest.java
+++ b/api/src/test/java/ca/bc/gov/educ/api/macro/validator/MacroPayloadValidatorTest.java
@@ -2,6 +2,7 @@ package ca.bc.gov.educ.api.macro.validator;
 
 import ca.bc.gov.educ.api.macro.MacroApiResourceApplication;
 import ca.bc.gov.educ.api.macro.constants.BusinessUseTypeCodes;
+import ca.bc.gov.educ.api.macro.repository.*;
 import ca.bc.gov.educ.api.macro.struct.v1.Macro;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.val;
@@ -11,6 +12,7 @@ import org.junit.runner.RunWith;
 import org.mockito.InjectMocks;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.*;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.junit4.SpringRunner;
 
@@ -26,11 +28,14 @@ public class MacroPayloadValidatorTest {
   @InjectMocks
   MacroPayloadValidator macroPayloadValidator;
 
+  @MockBean
+  private MacroRepository macroRepository;
+
   List<String> businessUseTypeCodes = List.of(BusinessUseTypeCodes.GMP.toString(), BusinessUseTypeCodes.UMP.toString(), BusinessUseTypeCodes.PENREG.toString());
 
   @Before
   public void before() {
-    this.macroPayloadValidator = new MacroPayloadValidator();
+    this.macroPayloadValidator = new MacroPayloadValidator(macroRepository);
   }
 
   @Test


### PR DESCRIPTION
Upgrade needed to allow ministry users to input a custom 3 letter code when creating a macro. 

Reasons:

- creating macros is a saga process. 
- we need to check that a macro being created doesn't already exist. Otherwise the saga would fail repeatedly due to the primary key constraint in the database. 